### PR TITLE
grid prop minColumnWidth is ignored if column minWidth is specified, ignore minWidth for SelectColumn

### DIFF
--- a/examples/demos/example13-all-features.js
+++ b/examples/demos/example13-all-features.js
@@ -17,7 +17,7 @@ export default class extends React.Component {
   constructor(props, context) {
     super(props, context);
     this.columns = [
-      SelectColumn,
+      { ...SelectColumn, width: 40 },
       {
         key: 'id',
         name: 'ID',
@@ -125,7 +125,7 @@ export default class extends React.Component {
     };
   }
 
-  createRows = (numberOfRows) => {
+  createRows = numberOfRows => {
     const rows = [];
     for (let i = 0; i < numberOfRows; i++) {
       rows[i] = this.createFakeRowObjectData(i);
@@ -133,7 +133,7 @@ export default class extends React.Component {
     return rows;
   };
 
-  createFakeRowObjectData = (index) => {
+  createFakeRowObjectData = index => {
     return {
       id: `id_${index}`,
       avatar: faker.image.avatar(),
@@ -177,7 +177,7 @@ export default class extends React.Component {
     this.setState({ rows });
   };
 
-  getRowAt = (index) => {
+  getRowAt = index => {
     if (index < 0 || index > this.getSize()) {
       return undefined;
     }
@@ -189,7 +189,7 @@ export default class extends React.Component {
     return this.state.rows.length;
   };
 
-  onSelectedRowsChange = (selectedRows) => {
+  onSelectedRowsChange = selectedRows => {
     this.setState({ selectedRows });
   };
 
@@ -208,6 +208,7 @@ export default class extends React.Component {
                 rowsCount={this.getSize()}
                 onGridRowsUpdated={this.handleGridRowsUpdated}
                 rowHeight={30}
+                minColumnWidth={150}
                 minWidth={width}
                 minHeight={height}
                 selectedRows={this.state.selectedRows}

--- a/packages/react-data-grid/src/common/types.ts
+++ b/packages/react-data-grid/src/common/types.ts
@@ -9,8 +9,9 @@ interface ColumnValue<TRow, TDependentValue = unknown, TField extends keyof TRow
   name: string;
   /** A unique key to distinguish each column */
   key: TField;
-  /** Column width. If not specified, it will be determined automatically based on grid width and specified widths of other columns*/
+  /** Column widths. If not specified, it will be determined automatically based on grid width and specified widths of other columns*/
   width?: number | string;
+  minWidth?: number | string;
   cellClass?: string;
   /** By adding an event object with callbacks for the native react events you can bind events to a specific column. That will not break the default behaviour of the grid and will run only for the specified column */
   events?: {


### PR DESCRIPTION
- Column new prop: minWidth
- Grid prop minColumnWidth is ignored if column has its prop minWidth specified, then it uses minWidth/width highest value
- SelectColumn can now have a width specified to stay fixed when minColumnWidth is specified
- updated all-features-13 which was already using SelectColumn to demo the added feature